### PR TITLE
Mentions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :production do
   gem 'puma'
   gem 'bugsnag', :require => 'bugsnag/railtie'
   gem 'aws-sdk'
+  gem 'websocket-native'
 end
 
 # See why https://github.com/rails/rails/commit/49c4af43ec

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'active_model_serializers', :github => 'rails-api/active_model_serializers'
 gem 'queue_classic'
 gem 'tubesock'
 gem 'redcarpet'
+gem 'redcarpet-socialable', :github => 'stas/redcapret-socialable'
 
 group :development do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -556,6 +556,7 @@ GEM
     vcr (2.8.0)
     websocket (1.1.2)
     websocket-driver (0.3.2)
+    websocket-native (1.0.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -614,3 +615,4 @@ DEPENDENCIES
   tubesock
   uglifier
   vcr
+  websocket-native

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: git://github.com/rails-api/active_model_serializers.git
-  revision: 36b917ef233b065d0d2581c1788d6823dfe1fbef
+  revision: 1ec499bd645448565cfa834b9f0fcbbfa6306ea5
   specs:
     active_model_serializers (0.9.0.alpha1)
       activemodel (>= 3.2)
@@ -88,7 +88,7 @@ GEM
     addressable (2.3.5)
     arel (4.0.1)
     atomic (1.1.14)
-    aws-sdk (1.31.3)
+    aws-sdk (1.32.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
@@ -115,9 +115,9 @@ GEM
     capistrano-rails (1.1.0)
       capistrano (>= 3.0.0)
       capistrano-bundler (>= 1.0.0)
-    capistrano-rbenv (2.0.0)
+    capistrano-rbenv (2.0.1)
       capistrano (~> 3.0)
-      sshkit (~> 1.2.0)
+      sshkit (~> 1.3)
     capybara (2.2.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -160,8 +160,8 @@ GEM
       handlebars-source (~> 1.2.1)
     erubis (2.7.0)
     execjs (2.0.2)
-    fabrication (2.9.4)
-    faraday (0.8.8)
+    fabrication (2.9.6)
+    faraday (0.8.9)
       multipart-post (~> 1.2.0)
     fast_gettext (0.8.1)
     ffaker (1.22.1)
@@ -180,7 +180,7 @@ GEM
       thor (>= 0.18.1)
     guard-migrate (1.0.0)
       guard (>= 1.3.0)
-    guard-rspec (4.2.3)
+    guard-rspec (4.2.4)
       guard (~> 2.1)
       rspec (>= 2.14, < 4.0)
     haml (4.0.5)
@@ -220,9 +220,9 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.5.2)
     minitest (4.7.5)
-    momentjs-rails (2.4.0)
+    momentjs-rails (2.5.0)
       railties (>= 3.1)
-    multi_json (1.8.2)
+    multi_json (1.8.4)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
     net-scp (1.1.2)
@@ -267,7 +267,7 @@ GEM
       pg (~> 0.17.0)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
-    racc (1.4.10)
+    racc (1.4.11)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -534,7 +534,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    sshkit (1.2.0)
+    sshkit (1.3.0)
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,13 @@ GIT
     ember-model-source (0.0.10)
       ember-source
 
+GIT
+  remote: git://github.com/stas/redcapret-socialable.git
+  revision: 19587437e4e6c28913a75bdf9286bd16f5e3f563
+  specs:
+    redcarpet-socialable (0.0.2)
+      redcarpet (>= 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -604,6 +611,7 @@ DEPENDENCIES
   rails
   readwritesettings
   redcarpet
+  redcarpet-socialable!
   rspec-rails
   rubinius-coverage
   rubysl

--- a/app/assets/javascripts/controllers/conversations_show_controller.js.coffee
+++ b/app/assets/javascripts/controllers/conversations_show_controller.js.coffee
@@ -87,6 +87,5 @@ Founden.ConversationsShowController = Ember.Controller.extend
     startMention: ->
       # TODO: DRY this, probably move to mentions-support component
       textarea = @get('messageForm.textarea').get(0)
-      textarea.value += '@'
-      textarea.selectionEnd += 1 if textarea.selectionEnd
+      textarea.value += ' '
       @get('messageForm.mentionsSupport').onAtKeyPress(textarea)

--- a/app/assets/javascripts/mixins/textarea_caret_mixin.js.coffee
+++ b/app/assets/javascripts/mixins/textarea_caret_mixin.js.coffee
@@ -56,3 +56,20 @@ Founden.TextAreaCaretMixin = Ember.Mixin.create Founden.KeyboardEventsMixin,
     # lynx
     else
       textarea.value
+
+  appendAfterCarret: (textarea, textToAppend) ->
+    newValue = @textBeforeCaret(textarea)
+    # Remove last typed character
+    newValue = newValue.substring(0, newValue.length - 1)
+    oldValue = textarea.value
+
+    # Snapshot old caret position including last character
+    caretPosition = newValue.length + 1
+    newValue += textToAppend
+
+    # Snapshot the new position inside textarea
+    newCaretPosition = newValue.length
+
+    newValue += oldValue.substring(caretPosition, oldValue.length)
+    textarea.value = newValue
+    textarea.selectionStart = textarea.selectionEnd = newCaretPosition

--- a/app/assets/javascripts/views/components/attachments-support.js.coffee
+++ b/app/assets/javascripts/views/components/attachments-support.js.coffee
@@ -53,9 +53,7 @@ Founden.AttachmentsSupportComponent = Ember.Component.extend Founden.TextAreaCar
     type.set('attachments', [])
     @set('selectedAttachmentType', type)
     textarea = @get('textarea')
-    oldValue = textarea.value
-    textarea.value = oldValue.substring(0, oldValue.length - 1)
-    textarea.selectionStart = textarea.selectionEnd = oldValue.length - 1
+    @appendAfterCarret(textarea, '')
     @set('isVisible', false)
 
   searchChanged: ( ->

--- a/app/assets/javascripts/views/components/mentions-support.js.coffee
+++ b/app/assets/javascripts/views/components/mentions-support.js.coffee
@@ -85,18 +85,7 @@ Founden.MentionsSupportComponent = Ember.Component.extend Founden.TextAreaCaretM
   appendMention: (user) ->
     mention = user.get('name')
     textarea = @get('textarea')
-    oldValue = textarea.value
-    newValue = @textBeforeCaret(textarea)
-    newValue += mention
-
-    # Snapshot the new position inside textarea
-    newCaretPosition = newValue.length
-
-    newValue +=
-      oldValue.substring(@textBeforeCaret(textarea).length, oldValue.length)
-    textarea.value = newValue
-    textarea.selectionStart = textarea.selectionEnd = newCaretPosition
-
+    @appendAfterCarret(textarea, mention)
     @get('parentView').sendAction('addMember', user)
 
   didInsertElement: ->

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,4 +6,13 @@ class UserMailer < ApplicationMailer
     mail(:to => @invitation.email, :subject => _('%s invites you to use %s.') % [
       @invitation.user.full_name, Founden::Config.app_name])
   end
+
+  # Sends a conversation mention
+  def mention(message_id, user_id)
+    @message = Message.find(message_id)
+    @user = User.find(user_id)
+    mail(:to => @user.email, :subject => _('%s mentioned you in %s on %s.') % [
+      @message.user.full_name, @message.conversation.title,
+      Founden::Config.app_name])
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -47,7 +47,13 @@ class Message < ActiveRecord::Base
       if self.content.include?(name)
         token = '@id:%d@' % user[0]
         content.sub!(name, token)
+        notify_mention(user[0])
       end
     end
+  end
+
+  # Sends a notification email to mentioned user
+  def notify_mention(user_id)
+    QC.enqueue('UserMailer.deliver', :mention, self.id, user_id)
   end
 end

--- a/app/views/user_mailer/mention.text.haml
+++ b/app/views/user_mailer/mention.text.haml
@@ -1,0 +1,10 @@
+= _('Hello from %s %s') % [Founden::Config.app_name, @user.full_name]
+\
+= _('%s mentioned you in a conversation: %s.') % [@message.user.full_name, @message.conversation.title]
+= _('To reply, visit %s') % root_url(:anchor => '/conversations/%s' % @message.conversation.slug)
+\
+= _('Thanks')
+\
+= '---'
+= _('Your %s team.') % Founden::Config.app_name
+= Founden::Config.app_id

--- a/config/initializers/redcarpet.rb
+++ b/config/initializers/redcarpet.rb
@@ -1,7 +1,28 @@
 require 'redcarpet'
+require 'redcarpet/socialable'
+
+# Our Redcarpet render class
+class Founden::MarkdownRender < Redcarpet::Render::HTML
+  include Redcarpet::Socialable::Mentions
+
+  # Regexp to match the mentions
+  def mention_regexp; '@id\:([\d]+)@' end
+
+  # Template to render a mention
+  def mention_template(user_name)
+    '<span class="mention">%s</span>' % user_name
+  end
+
+  # Validates a mention
+  def mention?(user_id)
+    if user = User.find_by(:id => user_id)
+      user.full_name
+    end
+  end
+end
 
 Founden::Application.config.markdown = Redcarpet::Markdown.new(
-  Redcarpet::Render::HTML.new({
+  Founden::MarkdownRender.new({
     :filter_html => true,
     :no_images => true,
     :no_links => false,

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -51,6 +51,13 @@ describe Api::V1::MessagesController do
       its(:content) { should include('em') }
       its(:content) { should include('code') }
       its(:content) { should include('h3') }
+
+      context 'and it has mentions' do
+        let(:markdown) { 'Mentions %s' % user.full_name }
+
+        its(:content) { should include(
+          '<span class="mention">%s</span>' % user.full_name) }
+      end
     end
 
     context 'when it has a summary' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -23,4 +23,21 @@ describe UserMailer do
     its(:to) { should include(invitation.email) }
   end
 
+  describe '#mention' do
+    let(:participant) { Fabricate(:user) }
+    let(:message) { Fabricate(:message, :user => user) }
+
+    before do
+      UserMailer.deliver(:mention, message.id, participant.id)
+    end
+
+    it_should_behave_like 'an email from us'
+    its('body.encoded') { should include(message.user.full_name) }
+    its('body.encoded') { should include(message.conversation.title) }
+    its('body.encoded') { should include(participant.full_name) }
+    its('body.encoded') { should include(
+      root_url(:anchor => '/conversations/%s' % message.conversation.slug)) }
+    its(:to) { should include(participant.email) }
+  end
+
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -26,5 +26,21 @@ describe Message do
 
       its(:content) { should eq(Sanitize.clean(content)) }
     end
+
+    context '#materialize_mentions' do
+      let(:conversation) { Fabricate(:conversation) }
+      let(:participant) { conversation.participants.first }
+      let(:content) do
+        Faker::Lorem.paragraph + participant.full_name + Faker::Lorem.paragraph
+      end
+      subject(:message) do
+        Fabricate(:message, :content => content, :conversation => conversation)
+      end
+
+      before { message.reload }
+
+      its(:content) { should_not include(participant.full_name) }
+      its(:content) { should include('@id:%d@' % participant.id) }
+    end
   end
 end


### PR DESCRIPTION
Most of the code for mentions is provided through `redcarpet-socialable`.

Mentions will send emails now and serialize any participant name into something like `@id:USER_ID@` which is later picked by the markdown renderer and materialized back into its username.

I also cleaned up a bit javascript which handles mentions and attachments to not include chars like `@` and `+`.

@stefangugurel please review and merge.
Thanks.
